### PR TITLE
Migrate to 2024.06.x

### DIFF
--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -14,13 +14,13 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           server-id: ossrhs01 # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
       - name: Build with Maven
-        run: mvn -B verify --file pom.xml
+        run: mvn -B clean install

--- a/.github/workflows/maven-publish-release.yml
+++ b/.github/workflows/maven-publish-release.yml
@@ -15,19 +15,19 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
-          server-id: ossrhs01 # Value of the distributionManagement/repository/id field of the pom.xml
+          server-id: 'sonatype-central' # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Change Versions
         run: mvn versions:set -DnewVersion=${{ github.ref_name }}-SNAPSHOT
-      - name: Publish to OSSRH with Apache Maven
-        run: mvn --batch-mode deploy
+      - name: Publish to Sonatype Central with Apache Maven
+        run: mvn --batch-mode deploy -P deploy-to-sonatype
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/maven-publish-snapshot.yml
+++ b/.github/workflows/maven-publish-snapshot.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - 'main'
       - '2022.06.x'
+      - '2023.06.x'
+      - '2024.06.x'
+
 
 jobs:
   build:
@@ -19,15 +22,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           server-id: 'sonatype-central' # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-      - name: Publish to OSSRH with Apache Maven
+      - name: Publish to Sonatype Central with Apache Maven
         run: mvn --batch-mode deploy -P deploy-to-sonatype
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -21,14 +21,14 @@
   <parent>
     <groupId>de.gbv.reposis</groupId>
     <artifactId>reposis_parent</artifactId>
-    <version>2023.06-SNAPSHOT</version>
+    <version>2024.06-SNAPSHOT</version>
   </parent>
 
   <artifactId>reposis_common</artifactId>
-  <version>2023.06-SNAPSHOT</version>
+  <version>2024.06-SNAPSHOT</version>
   <properties>
     <MCR.AppName>reposis-common</MCR.AppName>
-    <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
+    <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <node.version>v16.19.1</node.version>
   </properties>
 

--- a/src/main/java/de/gbv/reposis/agreement/VZGMailAgreementEventHandler.java
+++ b/src/main/java/de/gbv/reposis/agreement/VZGMailAgreementEventHandler.java
@@ -55,7 +55,7 @@ public class VZGMailAgreementEventHandler extends MCREventHandlerBase {
 
     @Override
     protected void handleObjectUpdated(MCREvent evt, MCRObject obj) {
-        final ArrayList<String> currentAgreements = obj.getService().getFlags("agreement");
+        final List<String> currentAgreements = obj.getService().getFlags("agreement");
 
         if(!MAILER_PROPERTY_SET){
             return;
@@ -68,7 +68,7 @@ public class VZGMailAgreementEventHandler extends MCREventHandlerBase {
         int oldAgreementsSize = 0;
         if (MCRMetadataManager.exists(obj.getId())) {
             final MCRObject retrieve = MCRMetadataManager.retrieveMCRObject(obj.getId());
-            final ArrayList<String> oldAgreements = retrieve.getService().getFlags("agreement");
+            final List<String> oldAgreements = retrieve.getService().getFlags("agreement");
             oldAgreementsSize = oldAgreements.size();
         }
 

--- a/src/main/java/de/gbv/reposis/metrics/scopus/MCRScopusMetricsProvider.java
+++ b/src/main/java/de/gbv/reposis/metrics/scopus/MCRScopusMetricsProvider.java
@@ -113,7 +113,7 @@ public class MCRScopusMetricsProvider extends MCRMetricsProvider {
                         LOGGER.error("Error while updating scopus metrics!", e);
                     }
                 } else if (response == 401 || response == 403) {
-                    LOGGER.error("Acces denied to the Scopus API - didn't add Scopus Metrics");
+                    LOGGER.error("Access denied to the Scopus API - didn't add Scopus Metrics");
                 } else {
                     LOGGER.info("Unknown '{}' Response from ScopusAPI - didn't add Scopus Metrics", resp.statusCode());
                 }

--- a/src/main/java/de/gbv/reposis/user/shibboleth/MCRSAMLEntitiesRealmFileUpdater.java
+++ b/src/main/java/de/gbv/reposis/user/shibboleth/MCRSAMLEntitiesRealmFileUpdater.java
@@ -3,6 +3,7 @@ package de.gbv.reposis.user.shibboleth;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -121,9 +122,8 @@ public class MCRSAMLEntitiesRealmFileUpdater extends MCRCronjob {
 
     @MCRProperty(name = "Url", required = true)
     public void setUrl(String url) throws MalformedURLException {
-        setUrl(new URL(url));
+        setUrl(URI.create(url).toURL());
     }
-
     public boolean isPreserveRealmsWithUsers() {
         return preserveRealmsWithUsers;
     }
@@ -215,7 +215,7 @@ public class MCRSAMLEntitiesRealmFileUpdater extends MCRCronjob {
 
     public Map<String, RealmInfo> getRemoteRealms() throws IOException, JDOMException {
         Document document = downloadIDPList();
-        HashMap<String, RealmInfo> realms = new HashMap();
+        HashMap<String, RealmInfo> realms = new HashMap<>();
 
         List<Element> entities = ENTITY_DESCRIPTOR_XPATH.evaluate(document);
 
@@ -288,7 +288,7 @@ public class MCRSAMLEntitiesRealmFileUpdater extends MCRCronjob {
 
     public static class RealmInfo {
         private String id;
-        private Map<String, String> labels = new HashMap();
+        private Map<String, String> labels = new HashMap<>();
         private String passwordChangeURL;
         private String loginURL;
         private String createURL;

--- a/src/test/resources/mycore.properties
+++ b/src/test/resources/mycore.properties
@@ -1,0 +1,6 @@
+##############################################################################
+# Agreement                                                                  #
+##############################################################################
+MIR.Agreement.File=agreement.pdf
+MIR.Agreement.MailTemplate=agreement_mail_template.xhtml
+MIR.Agreement.Genres.Skip=journal,series,collection,newspaper,series,bachelor_thesis,master_thesis,matura


### PR DESCRIPTION
This commit updates the project to use JDK 21 and Maven Dependency Plugin version 3.8.1.

The following changes were made:

- Updated the GitHub Actions workflows to use JDK 21.
- Updated the Maven Dependency Plugin version to 3.8.1 in pom.xml.
- Added branch filters for 2023.06.x and 2024.06.x to maven-publish-snapshot.yml
- Changed the version in pom.xml to 2024.06-SNAPSHOT
- Changed the maven verify command to maven clean install in maven-pr.yml